### PR TITLE
Use HTTPS in default action URLs

### DIFF
--- a/panel-plugin/xfce4-clipman-actions.xml.in
+++ b/panel-plugin/xfce4-clipman-actions.xml.in
@@ -37,21 +37,21 @@
 		<commands>
 			<command>
 				<name>Xfce Bug</name>
-				<exec>exo-open http://bugzilla.xfce.org/show_bug.cgi?id=\1</exec>
+				<exec>exo-open https://bugzilla.xfce.org/show_bug.cgi?id=\1</exec>
 			</command>
 			<command>
 				<name>GNOME Bug</name>
-				<exec>exo-open http://bugzilla.gnome.org/show_bug.cgi?id=\1</exec>
+				<exec>exo-open https://bugzilla.gnome.org/show_bug.cgi?id=\1</exec>
 			</command>
 		</commands>
 	</action>
 	<action>
 		<name>Long URL</name>
-		<regex>http://[^\s]{120,}</regex>
+		<regex>https?://[^\s]{120,}</regex>
 		<commands>
 			<command>
 				<name>Shrink the URL</name>
-				<exec>exo-open http://tinyurl.com/create.php?url=\0</exec>
+				<exec>exo-open https://tinyurl.com/create.php?url=\0</exec>
 			</command>
 		</commands>
 	</action>


### PR DESCRIPTION
Please fix the xfce gitlab screening process since it is clearly broken for first-time contributors -- even when using SSO signup.

- https://gitlab.xfce.org/panel-plugins/xfce4-clipman-plugin/-/merge_requests/36